### PR TITLE
Adding `git-statistics` executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ### Using the gem
 1. Acquire gem (`gem install git_statistics`)
-2. Run `git_statistics` in any directory that is a git repository (use -h for options)
+2. Run `git statistics` in any directory that is a git repository (use -h for options)
 
 ### Working with source
 1. Clone the repository

--- a/bin/git-statistics
+++ b/bin/git-statistics
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require 'git_statistics'
+
+GitStatistics::GitStatistics.new(ARGV).execute

--- a/git_statistics.gemspec
+++ b/git_statistics.gemspec
@@ -12,8 +12,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.files         = `git ls-files`.split($\)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.executables << 'git_statistics'
+  gem.executables   = %w[ git_statistics git-statistics ]
   gem.required_ruby_version = '>= 1.9.1'
   gem.add_dependency('json')
   gem.add_dependency('trollop')


### PR DESCRIPTION
This allows git uses to use the command `git statistics` rather than through the `git_statistics` command if they so choose.
