### PR TITLE
String#clean_for_authors instead of Utilities#clean_string

### DIFF
--- a/lib/git_statistics/collector.rb
+++ b/lib/git_statistics/collector.rb
@@ -31,7 +31,7 @@ module GitStatistics
       buffer = []
       pipe.each do |line|
 
-        line = Utilities.clean_string(line)
+        line = line.clean_for_authors
 
         # Extract the buffer (commit) when we match ','x5 in the log format (delimeter)
         if line.split(',').size == 5
@@ -61,7 +61,7 @@ module GitStatistics
                   " --no-color --find-copies-harder --numstat --encoding=utf-8 "\
                   "--summary --format=\"%H,%an,%ae,%ad,%p\"")
 
-      buffer = pipe.map { |line| Utilities.clean_string(line) }
+      buffer = pipe.map { |line| line.clean_for_authors }
 
       # Check that the buffer has valid information (i.e., sha was valid)
       if !buffer.empty? && buffer.first.split(',').first == sha
@@ -78,7 +78,7 @@ module GitStatistics
 
         # Remove the '*' leading the current branch
         line = line[1..-1] if line[0] == '*'
-        branches << Utilities.clean_string(line)
+        branches << line.clean_for_authors
       end
 
       return branches

--- a/lib/git_statistics/commit_line_extractor.rb
+++ b/lib/git_statistics/commit_line_extractor.rb
@@ -18,8 +18,8 @@ module GitStatistics
         split_file = Utilities.split_old_new_file(changes[2], changes[3])
         {:additions => changes[0].to_i,
           :deletions => changes[1].to_i,
-          :file => Utilities.clean_string(split_file[:new_file]),
-          :old_file => Utilities.clean_string(split_file[:old_file])}
+          :file => split_file[:new_file].clean_for_authors,
+          :old_file => split_file[:old_file].clean_for_authors}
       end
       return modified_or_renamed unless modified_or_renamed.empty?
 
@@ -27,15 +27,15 @@ module GitStatistics
       changes_are_right_size(addition_or_deletion, 3) do |changes|
         {:additions => changes[0].to_i,
           :deletions => changes[1].to_i,
-          :file => Utilities.clean_string(changes[2])}
+          :file => changes[2].clean_for_authors}
       end
     end
 
     def created_or_deleted
       changes = line.scan(CREATED_OR_DELETED).first
       changes_are_right_size(changes, 2) do |changes|
-        {:status => Utilities.clean_string(changes[0]),
-          :file => Utilities.clean_string(changes[1])}
+        {:status => changes[0].clean_for_authors,
+          :file => changes[1].clean_for_authors}
       end
     end
 
@@ -43,9 +43,9 @@ module GitStatistics
       changes = line.scan(RENAMED_OR_COPIED).first
       changes_are_right_size(changes, 4) do |changes|
         split_file = Utilities.split_old_new_file(changes[1], changes[2])
-        {:status => Utilities.clean_string(changes[0]),
-          :old_file => Utilities.clean_string(split_file[:old_file]),
-          :new_file => Utilities.clean_string(split_file[:new_file]),
+        {:status => changes[0].clean_for_authors,
+          :old_file => split_file[:old_file].clean_for_authors,
+          :new_file => split_file[:new_file].clean_for_authors,
           :similar => changes[3].to_i}
       end
     end

--- a/lib/git_statistics/core_ext/string.rb
+++ b/lib/git_statistics/core_ext/string.rb
@@ -1,0 +1,11 @@
+module GitStatistics
+  module StringExt
+    def clean_for_authors
+      self.strip.force_encoding("iso-8859-1").encode("utf-8")
+    end
+  end
+end
+
+class String
+  include GitStatistics::StringExt
+end

--- a/lib/git_statistics/initialize.rb
+++ b/lib/git_statistics/initialize.rb
@@ -5,6 +5,8 @@ require 'linguist'
 require 'os'
 require 'pathname'
 
+require 'git_statistics/core_ext/string'
+
 # Custom Blob for Grit to enable Linguist
 # This must load before other modules
 module Grit

--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -11,7 +11,7 @@ describe Collector do
   # Create buffer which is an array of cleaned lines
   let(:buffer) {
     fixture(fixture_file).readlines.collect do |line|
-      Utilities.clean_string(line)
+      line.clean_for_authors
     end
   }
 

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -54,7 +54,7 @@ describe Utilities do
 
   describe "#clean_string" do
     let(:unclean) {"  master   "}
-    let(:clean) {Utilities.clean_string(unclean)}
+    let(:clean) {unclean.clean_for_authors}
 
     context "with trailling spaces" do
       it {clean.should == "master"}


### PR DESCRIPTION
I'm not a huge fan of extending core classes myself, but this is much cleaner, and is a step closer to a better refactoring of lines in buffers.
