### PR TITLE
Loading the specs in a standard way

### DIFF
--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 include GitStatistics
 
 describe Collector do

--- a/spec/commits_spec.rb
+++ b/spec/commits_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 include GitStatistics
 
 describe Commits do

--- a/spec/results_spec.rb
+++ b/spec/results_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 include GitStatistics
 
 describe Results do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,10 @@
+$:.unshift File.expand_path("../../lib", __FILE__)
 require 'simplecov'
-
 SimpleCov.start do
   add_filter "/spec/"
 end
 
-require File.dirname(__FILE__) + '/../lib/git_statistics/initialize.rb'
+require 'git_statistics/initialize'
 
 def fixture(file)
   File.new(File.dirname(__FILE__) + '/fixtures/' + file, 'r')

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/spec_helper'
+require 'spec_helper'
 include GitStatistics
 
 describe Utilities do


### PR DESCRIPTION
RSpec standardizes on simply using `require 'spec_helper'`. It also makes sense to add the `lib` directory to the path so you can use `require 'git_statistics/some_file_name` instead of a `File.expand_path` means.
