### PR TITLE
Fix failing spec in Collector

### DIFF
--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -253,7 +253,7 @@ describe Collector do
 
     context "with invalid sha" do
       let(:sha) { "111111aa111a11111a11aa11aaaa11a111111a11" }
-      it { should be_nil }
+      it { should be_empty }
     end
   end
 


### PR DESCRIPTION
Fix:
- GitStatistics::Collector#fall_back_collect_commit with invalid sha as
  it was expecting a nil when we now return an empty array
