### PR TITLE
Removing duplication in commits and collector specs

### DIFF
--- a/spec/collector_spec.rb
+++ b/spec/collector_spec.rb
@@ -264,13 +264,13 @@ describe Collector do
     context "with valid blob" do
       let(:file) {{:file => "Gemfile.lock"}}
       it { should be_a Grit::Blob }
-      its(:name) { should == file[:file].split(File::Separator).last }
+      its(:name) { should == File.basename(file[:file]) }
     end
 
     context "with deleted file" do
       let(:file) {{:file => "spec/collector_spec.rb"}}
       it { should be_a Grit::Blob }
-      its(:name) { should == file[:file].split(File::Separator).last }
+      its(:name) { should == File.basename(file[:file]) }
     end
 
     context "with invalid blob" do


### PR DESCRIPTION
Does a few things:
- Removes use of `File::Separator` and string splitting in favor of simple `File.basename` standard.
- Removes duplication of specs.
- Removed extra `subject` declarations.
- Promoted local variables to proper `let` methods.
