### PR TITLE
Utilities.get_repository refactoring

### DIFF
--- a/lib/git_statistics/collector.rb
+++ b/lib/git_statistics/collector.rb
@@ -6,9 +6,6 @@ module GitStatistics
     def initialize(verbose, limit, fresh, pretty)
       @verbose = verbose
       @repo = Utilities.get_repository
-
-      raise "No Git repository found" if @repo.nil?
-
       @repo_path = File.expand_path("..", @repo.path)
       @commits_path = File.join(@repo_path, ".git_statistics")
       @commits = Commits.new(@commits_path, fresh, limit, pretty)

--- a/lib/git_statistics/utilities.rb
+++ b/lib/git_statistics/utilities.rb
@@ -1,17 +1,16 @@
 module GitStatistics
   module Utilities
+
+    class NotInRepository < StandardError; end
+
     def self.get_repository(path = Dir.pwd)
-      # Connect to git repository if it exists
-      directory = Pathname.new(path)
-      repo = nil
-      while !directory.root? do
-        begin
-          repo = Grit::Repo.new(directory)
-          return repo
-        rescue
-          directory = directory.parent
-        end
-      end
+      ascender = Pathname.new(path).to_enum(:ascend)
+      repo_path = ascender.detect { |path| (path + '.git').exist? }
+      raise NotInRepository if repo_path.nil?
+      Grit::Repo.new(repo_path.to_s)
+    rescue NotInRepository
+      puts "You must be within a Git project to run git-statistics."
+      exit 0
     end
 
     def self.max_length_in_list(list, max = nil)

--- a/spec/utilities_spec.rb
+++ b/spec/utilities_spec.rb
@@ -4,20 +4,21 @@ include GitStatistics
 describe Utilities do
 
   describe "#get_repository" do
-    subject {Utilities.get_repository(dir)}
+    subject { Utilities.get_repository(dir) }
 
     context "with root directory" do
-      let(:dir) {Dir.pwd} # git_statistics/
+      let(:dir) { Dir.pwd } # git_statistics/
       it { should be_a Grit::Repo }
     end
 
     context "with sub directory" do
-      let(:dir) {File.dirname(__FILE__)} # git_statistics/spec/
+      let(:dir) { File.dirname(__FILE__) } # git_statistics/spec/
       it { should be_a Grit::Repo }
     end
 
     context "when not in a repository directory" do
-      let(:dir) {Dir.pwd + "../"} # git_statistics/../
+      before { Utilities.should_receive(:exit) }
+      let(:dir) { Dir.home } # /Users/username/
       it { should be_nil }
     end
   end


### PR DESCRIPTION
`Utilities.get_repository` always bothered me. I don't generally like `while` loops in Ruby, so I promoted it to use the `Pathname.ascend` (see [docs](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/pathname/rdoc/Pathname.html#method-i-ascend) for more info). 

Also, use `exit 0` with a simple `puts` for informing the user of the error instead of a straight `raise`. Looks nicer :wink: 

If you feel it's a little too tricky, I'll refactor for a bit more clarity and squash my commits...
