### PR TITLE
Add the 'lib' directory to the load path

### DIFF
--- a/bin/git-statistics
+++ b/bin/git-statistics
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+$:.unshift File.expand_path("../../lib", __FILE__)
 require 'git_statistics'
 
 GitStatistics::GitStatistics.new(ARGV).execute

--- a/bin/git_statistics
+++ b/bin/git_statistics
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+$:.unshift File.expand_path("../../lib", __FILE__)
 require 'git_statistics'
 
 GitStatistics::GitStatistics.new(ARGV).execute


### PR DESCRIPTION
The intent behind this move would be to eliminate the need to `rake install` the gem as by default it attempts to load the `git_statistics` gem rather than the file in the path.

**Before:**

```
$ ./bin/git_statistics
.... some error
.... fix error
$ rake install
.... install gem again
$ ./bin/git_statistics
.... it works!
```

**After:**

```
$ ./bin/git_statistics
.... some error
.... fix error
$ ./bin/git_statistics
.... it works!
```
