### PR TITLE
Fix for #37 - Travis CI issue on pipe_spec.rb

### DIFF
--- a/spec/pipe_spec.rb
+++ b/spec/pipe_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 include GitStatistics
 
 describe Pipe do
-  let(:command) { 'time' }
+  let(:command) { 'git' }
   let(:line)    { stub }
   let(:pipe)    { Pipe.new(command) }
 


### PR DESCRIPTION
Hopefully this fixes the Travis CI issue (`time` command is not found)
