### PR TITLE
Redirect stderr to /dev/null to avoid extra output

### DIFF
--- a/lib/git_statistics/pipe.rb
+++ b/lib/git_statistics/pipe.rb
@@ -21,7 +21,7 @@ module GitStatistics
     end
 
     def io
-      open("|#{command}")
+      open("|#{command} 2>/dev/null")
     end
   end
 end

--- a/spec/pipe_spec.rb
+++ b/spec/pipe_spec.rb
@@ -50,7 +50,7 @@ describe Pipe do
 
   context "#io" do
     it "should call #open and pass the command through" do
-      pipe.should_receive(:open).with("|#{command}")
+      pipe.should_receive(:open).with(/\A|#{command}/)
       pipe.io
     end
     it { pipe.io.should be_an IO }


### PR DESCRIPTION
This stops stuff (such as in the tests) from having `fatal bad object 1p8720187231209872130987` thrown at you when you don't necessarily care as a `git_statistics` user.
