### PR TITLE
Main class Refactorings

### DIFF
--- a/bin/git-statistics
+++ b/bin/git-statistics
@@ -3,4 +3,4 @@
 $:.unshift File.expand_path("../../lib", __FILE__)
 require 'git_statistics'
 
-GitStatistics::GitStatistics.new.execute
+GitStatistics::CLI.new.execute

--- a/bin/git_statistics
+++ b/bin/git_statistics
@@ -3,4 +3,4 @@
 $:.unshift File.expand_path("../../lib", __FILE__)
 require 'git_statistics'
 
-GitStatistics::GitStatistics.new.execute
+GitStatistics::CLI.new.execute


### PR DESCRIPTION
Due to the confusing nature of a module and a class having the same name, rename the `GitStatistics` class to `CLI`.

The `Cli#execute` method was also doing way too much. Break down the complexity into smaller pieces to reduce comment noise and make eventual integration testing easier to accomplish.
